### PR TITLE
Issue 2: Always use HTTPS with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # Tiny Tiny RSS running on Docker
+
+## Requirements
+
+- Docker
+- Docker Compose
+- Make
+- [Traefik running through Docker](https://github.com/damien-carcel/traefik-as-local-reverse-proxy) to access the
+  application through HTTPS.
+
+## Running Tiny Tiny RSS
+
+Start the containers:
+```bash
+$ make up
+```
+
+Then access the application through [ttrss.docker.localhost](https://ttrss.docker.localhost).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,13 @@ services:
   front:
     image: 'carcel/ttrss:nginx'
     labels:
-      - 'traefik.http.routers.skeleton-api.rule=Host(`${TTRSS_DOMAIN_NAME:-ttrss.docker.localhost}`)'
+      - 'traefik.http.middlewares.redirect-ttrss-http-to-https.redirectScheme.scheme=https'
+      - 'traefik.http.routers.ttrss.entrypoints=web'
+      - 'traefik.http.routers.ttrss.middlewares=redirect-ttrss-http-to-https'
+      - 'traefik.http.routers.ttrss.rule=Host(`${TTRSS_DOMAIN_NAME:-ttrss.docker.localhost}`)'
+      - 'traefik.http.routers.ttrss-with-https.entrypoints=websecure'
+      - 'traefik.http.routers.ttrss-with-https.rule=Host(`${TTRSS_DOMAIN_NAME:-ttrss.docker.localhost}`)'
+      - 'traefik.http.routers.ttrss-with-https.tls=true'
     networks:
       - proxy
       - ttrss


### PR DESCRIPTION
## Description

Use recently updated [Traefik configuration](https://github.com/damien-carcel/traefik-as-local-reverse-proxy) to access the application through HTTPS.

## Definition Of Done

| Q               | A
| ----------------| ---
| Related tickets | #2
| Documentation   | OK

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
